### PR TITLE
Added message type 1830 -  Network Management Advice Response to 93 spec. (ref: ISO 8583:1993)

### DIFF
--- a/src/msgTypes.ts
+++ b/src/msgTypes.ts
@@ -161,6 +161,7 @@ const message_types: Version = {
     '1801': 'Network Management request repeat',
     '1810': 'Network Management request response',
     '1820': 'Network Management advice',
+    '1830': 'Network Management advice Response',
   },
   2003: {
     '2100': 'Authorization request',


### PR DESCRIPTION
Adding a missing message type for spec 1993 - (1830 Network Management Advice Response)

Thanks!